### PR TITLE
match on lower case room names

### DIFF
--- a/bash_completions
+++ b/bash_completions
@@ -1,7 +1,7 @@
 _denim_completion_rooms()
 {
   if [[ -f ~/.denim/rooms ]]; then
-    room_names=`awk '{ print $1 }' ~/.denim/rooms`
+    room_names=`awk '{ print tolower($1) }' ~/.denim/rooms`
     if [ $COMP_CWORD -eq 2 ]; then
         COMPREPLY+=($(compgen -W "$room_names" -- "${COMP_WORDS[2]}"))
         return 0


### PR DESCRIPTION
another half solution. Now matches against the lower case letters you type. However, does not match typed upper case characters.

I could just as easily have lower cased the names in my rooms file except that the standard rooms file js upper.